### PR TITLE
Add header/query/form injectors for Seq types

### DIFF
--- a/src/main/java/io/dropwizard/vavr/VavrBundle.java
+++ b/src/main/java/io/dropwizard/vavr/VavrBundle.java
@@ -4,6 +4,7 @@ import io.dropwizard.Bundle;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.vavr.jersey.CollectionParamFeature;
 import io.dropwizard.vavr.jersey.EitherMessageBodyWriter;
 import io.dropwizard.vavr.jersey.EmptyValueExceptionMapper;
 import io.dropwizard.vavr.jersey.LazyParamFeature;
@@ -67,6 +68,7 @@ public class VavrBundle implements Bundle {
         environment.jersey().register(EmptyValueExceptionMapper.class);
         environment.jersey().register(LazyParamFeature.class);
         environment.jersey().register(OptionParamFeature.class);
+        environment.jersey().register(CollectionParamFeature.class);
 
         // These MessageBodyWriters will shadow JacksonMessageBodyProvider and thus make it impossible
         // to serialize or deserialize Either<Left, Right> or classes based on Value<T>, such as Option<T>

--- a/src/main/java/io/dropwizard/vavr/jersey/CollectionParamBinder.java
+++ b/src/main/java/io/dropwizard/vavr/jersey/CollectionParamBinder.java
@@ -1,0 +1,55 @@
+package io.dropwizard.vavr.jersey;
+
+import org.glassfish.hk2.api.InjectionResolver;
+import org.glassfish.hk2.api.TypeLiteral;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.internal.inject.ParamInjectionResolver;
+import org.glassfish.jersey.server.spi.internal.ValueFactoryProvider;
+
+import javax.inject.Singleton;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.QueryParam;
+
+public class CollectionParamBinder extends AbstractBinder {
+    @Override
+    protected void configure() {
+        bind(CollectionValueFactoryProvider.CollectionQueryParamFactoryProvider.class)
+            .to(ValueFactoryProvider.class)
+            .in(Singleton.class);
+        bind(CollectionValueFactoryProvider.CollectionFormParamFactoryProvider.class)
+            .to(ValueFactoryProvider.class)
+            .in(Singleton.class);
+        bind(CollectionValueFactoryProvider.CollectionHeaderParamFactoryProvider.class)
+            .to(ValueFactoryProvider.class)
+            .in(Singleton.class);
+
+        bind(QueryParamInjectionResolver.class)
+            .to(new TypeLiteral<InjectionResolver<QueryParam>>() {})
+            .in(Singleton.class);
+        bind(FormParamInjectionResolver.class)
+            .to(new TypeLiteral<InjectionResolver<FormParam>>() {})
+            .in(Singleton.class);
+        bind(HeaderParamInjectionResolver.class)
+            .to(new TypeLiteral<InjectionResolver<HeaderParam>>() {})
+            .in(Singleton.class);
+    }
+
+    private static class QueryParamInjectionResolver extends ParamInjectionResolver<QueryParam> {
+        public QueryParamInjectionResolver() {
+            super(CollectionValueFactoryProvider.CollectionQueryParamFactoryProvider.class);
+        }
+    }
+
+    private static class FormParamInjectionResolver extends ParamInjectionResolver<FormParam> {
+        public FormParamInjectionResolver() {
+            super(CollectionValueFactoryProvider.CollectionFormParamFactoryProvider.class);
+        }
+    }
+
+    private static class HeaderParamInjectionResolver extends ParamInjectionResolver<HeaderParam> {
+        public HeaderParamInjectionResolver() {
+            super(CollectionValueFactoryProvider.CollectionHeaderParamFactoryProvider.class);
+        }
+    }
+}

--- a/src/main/java/io/dropwizard/vavr/jersey/CollectionParamFeature.java
+++ b/src/main/java/io/dropwizard/vavr/jersey/CollectionParamFeature.java
@@ -1,0 +1,12 @@
+package io.dropwizard.vavr.jersey;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+public class CollectionParamFeature implements Feature {
+    @Override
+    public boolean configure(final FeatureContext context) {
+        context.register(new CollectionParamBinder());
+        return true;
+    }
+}

--- a/src/main/java/io/dropwizard/vavr/jersey/CollectionParameterExtractor.java
+++ b/src/main/java/io/dropwizard/vavr/jersey/CollectionParameterExtractor.java
@@ -1,0 +1,45 @@
+package io.dropwizard.vavr.jersey;
+
+import io.vavr.collection.Seq;
+import io.vavr.control.Option;
+import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractor;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+class CollectionParameterExtractor<A, B extends Seq<String>> implements MultivaluedParameterExtractor<Seq<A>> {
+    private final String name;
+    private final Option<String> defaultValue;
+    private final Function<String, A> fromString;
+    private final Function<List<String>, B> collBuilder;
+
+    CollectionParameterExtractor(final String name,
+                                 final Option<String> defaultValue,
+                                 final Function<String, A> fromString,
+                                 final Function<List<String>, B> collBuilder) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.fromString = fromString;
+        this.collBuilder = collBuilder;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getDefaultValueString() {
+        return this.defaultValue.getOrNull();
+    }
+
+    @Override
+    public Seq<A> extract(final MultivaluedMap<String, String> parameters) {
+        return this.collBuilder.apply(
+            Option.of(parameters.get(this.name))
+                .getOrElse(() -> defaultValue.map(Collections::singletonList).getOrElse(Collections.emptyList()))
+        ).map(this.fromString);
+    }
+}

--- a/src/main/java/io/dropwizard/vavr/jersey/CollectionValueFactoryProvider.java
+++ b/src/main/java/io/dropwizard/vavr/jersey/CollectionValueFactoryProvider.java
@@ -1,0 +1,124 @@
+package io.dropwizard.vavr.jersey;
+
+import io.vavr.collection.Array;
+import io.vavr.collection.List;
+import io.vavr.collection.Vector;
+import io.vavr.control.Option;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.internal.inject.Providers;
+import org.glassfish.jersey.internal.util.ReflectionHelper;
+import org.glassfish.jersey.server.internal.inject.AbstractContainerRequestValueFactory;
+import org.glassfish.jersey.server.internal.inject.AbstractValueFactoryProvider;
+import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractor;
+import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractorProvider;
+import org.glassfish.jersey.server.model.Parameter;
+
+import javax.inject.Inject;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.function.Function;
+
+abstract class CollectionValueFactoryProvider extends AbstractValueFactoryProvider {
+    protected CollectionValueFactoryProvider(final MultivaluedParameterExtractorProvider mpep,
+                                             final ServiceLocator locator,
+                                             final Parameter.Source... compatibleSources) {
+        super(mpep, locator, compatibleSources);
+    }
+
+    @Override
+    protected Factory<?> createValueFactory(final Parameter parameter) {
+        final Option<String> name = Option.of(parameter.getSourceName());
+        final Option<String> defaultValue = Option.of(parameter.getDefaultValue());
+
+        return name
+            .filter(n -> !n.isEmpty())
+            .flatMap(n ->
+                findParamConverter(parameter.getType(), parameter.getAnnotations())
+                    .map(conv -> (Function<String, Object>) conv::fromString)
+                    .flatMap(conv -> buildExtractor(parameter.getRawType(), n, defaultValue, conv))
+                    .map(extractor -> buildFactory(extractor, !parameter.isEncoded()))
+            )
+            .getOrNull();
+    }
+
+    private Option<MultivaluedParameterExtractor<?>> buildExtractor(final Class<?> rawClass,
+                                                                    final String name,
+                                                                    final Option<String> defaultValue,
+                                                                    final Function<String, Object> conv) {
+        if (rawClass.equals(Vector.class)) {
+            return Option.of(new CollectionParameterExtractor<>(name, defaultValue, conv, Vector::ofAll));
+        } else if (rawClass.equals(List.class)) {
+            return Option.of(new CollectionParameterExtractor<>(name, defaultValue, conv, List::ofAll));
+        } else if (rawClass.equals(Array.class)) {
+            return Option.of(new CollectionParameterExtractor<>(name, defaultValue, conv, Array::ofAll));
+        } else {
+            return Option.none();
+        }
+    }
+
+    protected abstract AbstractContainerRequestValueFactory<?> buildFactory(final MultivaluedParameterExtractor<?> extractor, final boolean decode);
+
+    @SuppressWarnings("unchecked")
+    private Option<ParamConverter<Object>> findParamConverter(final Type type, final Annotation[] annotations) {
+        return List.ofAll(ReflectionHelper.getTypeArgumentAndClass(type))
+            .headOption()
+            .flatMap(ctp -> {
+                if (ctp.rawClass().equals(String.class)) {
+                    return Option.<ParamConverter<Object>>some(new ParamConverter<Object>() {
+                        @Override
+                        public Object fromString(final String value) {
+                            return value;
+                        }
+
+                        @Override
+                        public String toString(final Object value) {
+                            return value.toString();
+                        }
+                    });
+                } else {
+                    return List.ofAll(Providers.getProviders(getLocator(), ParamConverterProvider.class)).flatMap(provider ->
+                        Option.of((ParamConverter<Object>) provider.getConverter(ctp.rawClass(), ctp.type(), annotations))
+                    ).headOption();
+                }
+            });
+    }
+
+    static class CollectionQueryParamFactoryProvider extends CollectionValueFactoryProvider {
+        @Inject
+        public CollectionQueryParamFactoryProvider(final MultivaluedParameterExtractorProvider mpep, final ServiceLocator locator) {
+            super(mpep, locator, Parameter.Source.QUERY);
+        }
+
+        @Override
+        protected AbstractContainerRequestValueFactory<?> buildFactory(final MultivaluedParameterExtractor<?> extractor, boolean decode) {
+            return new ParameterValueFactories.QueryParamValueFactory(extractor, decode);
+        }
+    }
+
+    static class CollectionFormParamFactoryProvider extends CollectionValueFactoryProvider {
+        @Inject
+        public CollectionFormParamFactoryProvider(final MultivaluedParameterExtractorProvider mpep, final ServiceLocator locator) {
+            super(mpep, locator, Parameter.Source.FORM);
+        }
+
+        @Override
+        protected AbstractContainerRequestValueFactory<?> buildFactory(final MultivaluedParameterExtractor<?> extractor, boolean decode) {
+            return new ParameterValueFactories.FormParamValueFactory(extractor);
+        }
+    }
+
+    static class CollectionHeaderParamFactoryProvider extends CollectionValueFactoryProvider {
+        @Inject
+        public CollectionHeaderParamFactoryProvider(final MultivaluedParameterExtractorProvider mpep, final ServiceLocator locator) {
+            super(mpep, locator, Parameter.Source.HEADER);
+        }
+
+        @Override
+        protected AbstractContainerRequestValueFactory<?> buildFactory(final MultivaluedParameterExtractor<?> extractor, boolean decode) {
+            return new ParameterValueFactories.HeaderParamValueFactory(extractor);
+        }
+    }
+}

--- a/src/main/java/io/dropwizard/vavr/jersey/ParameterValueFactories.java
+++ b/src/main/java/io/dropwizard/vavr/jersey/ParameterValueFactories.java
@@ -1,0 +1,65 @@
+package io.dropwizard.vavr.jersey;
+
+import io.vavr.control.Try;
+import org.glassfish.jersey.server.ParamException;
+import org.glassfish.jersey.server.internal.inject.AbstractContainerRequestValueFactory;
+import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractor;
+
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MultivaluedMap;
+
+abstract class ParameterValueFactories {
+    static class QueryParamValueFactory extends AbstractContainerRequestValueFactory<Object> {
+        private final MultivaluedParameterExtractor<?> extractor;
+        private final boolean decode;
+
+        public QueryParamValueFactory(final MultivaluedParameterExtractor<?> extractor, boolean decode) {
+            this.extractor = extractor;
+            this.decode = decode;
+        }
+
+        @Override
+        public Object provide() {
+            return Try.of(() -> {
+                final MultivaluedMap<String, String> parameters = getContainerRequest().getUriInfo().getQueryParameters(decode);
+                return extractor.extract(parameters);
+            }).getOrElseThrow(e -> new ParamException.QueryParamException(e.getCause(), extractor.getName(), extractor.getDefaultValueString()));
+        }
+    }
+
+    static class FormParamValueFactory extends AbstractContainerRequestValueFactory<Object> {
+        private final MultivaluedParameterExtractor<?> extractor;
+
+        public FormParamValueFactory(final MultivaluedParameterExtractor<?> extractor) {
+            this.extractor = extractor;
+        }
+
+        @Override
+        public Object provide() {
+            return Try.of(() -> {
+                getContainerRequest().bufferEntity();
+                final Form form = getContainerRequest().readEntity(Form.class);
+                return extractor.extract(form.asMap());
+            }).getOrElseThrow(e -> new ParamException.FormParamException(e.getCause(), extractor.getName(), extractor.getDefaultValueString()));
+        }
+    }
+
+    static class HeaderParamValueFactory extends AbstractContainerRequestValueFactory<Object> {
+        private final MultivaluedParameterExtractor<?> extractor;
+
+        public HeaderParamValueFactory(MultivaluedParameterExtractor<?> extractor) {
+            this.extractor = extractor;
+        }
+
+        @Override
+        public Object provide() {
+            return Try
+                .of(() -> extractor.extract(getContainerRequest().getHeaders()))
+                .getOrElseThrow(e -> new ParamException.HeaderParamException(e.getCause(), extractor.getName(), extractor.getDefaultValueString()));
+        }
+    }
+
+    private ParameterValueFactories() {
+        throw new AssertionError();
+    }
+}

--- a/src/test/java/io/dropwizard/vavr/jersey/CollectionValueFactoryProviderTest.java
+++ b/src/test/java/io/dropwizard/vavr/jersey/CollectionValueFactoryProviderTest.java
@@ -1,0 +1,170 @@
+package io.dropwizard.vavr.jersey;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.logging.BootstrapLogging;
+import io.vavr.collection.Array;
+import io.vavr.collection.List;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Vector;
+import io.vavr.jackson.datatype.VavrModule;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionValueFactoryProviderTest extends JerseyTest {
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+            .register(new JacksonMessageBodyProvider(new ObjectMapper().registerModule(new VavrModule())))
+            .register(CollectionParamFeature.class)
+            .register(TestResource.class);
+    }
+
+    @Test
+    public void headerElements() {
+        assertThat(
+            target("/header")
+                .request()
+                .header("paramV", "Foobar V")
+                .header("paramV", "Baz V")
+                .header("paramL", "Foobar L")
+                .header("paramL", "Baz L")
+                .header("paramA", "Foobar A")
+                .header("paramA", "Baz A")
+                .get(new GenericType<java.util.List<String>>() {})
+        ).containsExactly(
+            "Foobar V",
+            "Baz V",
+            "Foobar L",
+            "Baz L",
+            "Foobar A",
+            "Baz A"
+        );
+    }
+
+    @Test
+    public void headersEmpty() {
+        assertThat(
+            target("/header")
+                .request()
+                .get(new GenericType<java.util.List<String>>() {})
+        ).isEmpty();
+    }
+
+    @Test
+    public void queryElements() {
+        assertThat(
+            target("/query")
+                .queryParam("paramV", "Foobar V")
+                .queryParam("paramV", "Baz V")
+                .queryParam("paramL", "Foobar L")
+                .queryParam("paramL", "Baz L")
+                .queryParam("paramA", "Foobar A")
+                .queryParam("paramA", "Baz A")
+                .request()
+                .get(new GenericType<java.util.List<String>>() {})
+        ).containsExactly(
+            "Foobar V",
+            "Baz V",
+            "Foobar L",
+            "Baz L",
+            "Foobar A",
+            "Baz A"
+        );
+    }
+
+    @Test
+    public void queryEmpty() {
+        assertThat(
+            target("/query")
+                .request()
+                .get(new GenericType<java.util.List<String>>() {})
+        ).isEmpty();
+    }
+
+    @Test
+    public void formElements() {
+        final Entity<Form> entity = Entity.form(
+            new Form()
+                .param("paramV", "Foobar V")
+                .param("paramV", "Baz V")
+                .param("paramL", "Foobar L")
+                .param("paramL", "Baz L")
+                .param("paramA", "Foobar A")
+                .param("paramA", "Baz A")
+        );
+        assertThat(
+            target("/form")
+                .request()
+                .post(entity, new GenericType<java.util.List<String>>() {})
+        ).containsExactly(
+            "Foobar V",
+            "Baz V",
+            "Foobar L",
+            "Baz L",
+            "Foobar A",
+            "Baz A"
+        );
+    }
+
+    @Test
+    public void formEmpty() {
+        final Entity<Form> entity = Entity.form(new Form());
+        assertThat(
+            target("/form")
+                .request()
+                .post(entity, new GenericType<java.util.List<String>>() {})
+        ).isEmpty();
+    }
+
+    @Path("/")
+    @Produces(MediaType.APPLICATION_JSON)
+    public static class TestResource {
+        @GET
+        @Path("header")
+        public Seq<String> header(@HeaderParam("paramV") final Vector<String> paramV,
+                                  @HeaderParam("paramL") final List<String> paramL,
+                                  @HeaderParam("paramA") final Array<String> paramA) {
+            return Vector.ofAll(paramV).appendAll(paramL).appendAll(paramA);
+        }
+
+        @GET
+        @Path("query")
+        public Seq<String> query(@QueryParam("paramV") final Vector<String> paramV,
+                                 @QueryParam("paramL") final List<String> paramL,
+                                 @QueryParam("paramA") final Array<String> paramA) {
+            return Vector.ofAll(paramV).appendAll(paramL).appendAll(paramA);
+        }
+
+        @POST
+        @Path("form")
+        public Seq<String> form(@FormParam("paramV") final Vector<String> paramV,
+                                @FormParam("paramL") final List<String> paramL,
+                                @FormParam("paramA") final Array<String> paramA) {
+            return Vector.ofAll(paramV).appendAll(paramL).appendAll(paramA);
+        }
+    }
+}


### PR DESCRIPTION
This adds support for injecting Vavr `List`, `Vector`, and `Array` into resource methods using `@HeaderParam`, `@QueryParam`, and `@FormParam`.

This PR is for the Dropwizard 1.3.x branch.  Will also submit one for 2.0.x.