### PR TITLE
Add header/query/form injectors for Seq types

### DIFF
--- a/src/main/java/io/dropwizard/vavr/VavrBundle.java
+++ b/src/main/java/io/dropwizard/vavr/VavrBundle.java
@@ -4,6 +4,7 @@ import io.dropwizard.Bundle;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import io.dropwizard.vavr.jersey.CollectionParamFeature;
 import io.dropwizard.vavr.jersey.EitherMessageBodyWriter;
 import io.dropwizard.vavr.jersey.EmptyValueExceptionMapper;
 import io.dropwizard.vavr.jersey.LazyParamFeature;
@@ -67,6 +68,7 @@ public class VavrBundle implements Bundle {
         environment.jersey().register(EmptyValueExceptionMapper.class);
         environment.jersey().register(LazyParamFeature.class);
         environment.jersey().register(OptionParamFeature.class);
+        environment.jersey().register(CollectionParamFeature.class);
 
         // These MessageBodyWriters will shadow JacksonMessageBodyProvider and thus make it impossible
         // to serialize or deserialize Either<Left, Right> or classes based on Value<T>, such as Option<T>

--- a/src/main/java/io/dropwizard/vavr/jersey/CollectionParamBinder.java
+++ b/src/main/java/io/dropwizard/vavr/jersey/CollectionParamBinder.java
@@ -1,0 +1,71 @@
+package io.dropwizard.vavr.jersey;
+
+import org.glassfish.hk2.api.InjectionResolver;
+import org.glassfish.hk2.api.TypeLiteral;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.internal.inject.InjectionManager;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractorProvider;
+import org.glassfish.jersey.server.internal.inject.ParamInjectionResolver;
+import org.glassfish.jersey.server.internal.process.RequestProcessingContextReference;
+import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.QueryParam;
+
+public class CollectionParamBinder extends AbstractBinder {
+    @Override
+    protected void configure() {
+        bind(CollectionValueParamProvider.CollectionQueryParamProvider.class)
+            .to(ValueParamProvider.class)
+            .in(Singleton.class);
+        bind(CollectionValueParamProvider.CollectionFormParamProvider.class)
+            .to(ValueParamProvider.class)
+            .in(Singleton.class);
+        bind(CollectionValueParamProvider.CollectionHeaderParamProvider.class)
+            .to(ValueParamProvider.class)
+            .in(Singleton.class);
+
+        bind(QueryParamInjectionResolver.class)
+            .to(new TypeLiteral<InjectionResolver<QueryParam>>() {})
+            .in(Singleton.class);
+        bind(FormParamInjectionResolver.class)
+            .to(new TypeLiteral<InjectionResolver<FormParam>>() {})
+            .in(Singleton.class);
+        bind(HeaderParamInjectionResolver.class)
+            .to(new TypeLiteral<InjectionResolver<HeaderParam>>() {})
+            .in(Singleton.class);
+    }
+
+    private static Provider<ContainerRequest> getContainerRequestProvider(final InjectionManager injectionManager) {
+        return () -> {
+            RequestProcessingContextReference reference = injectionManager.getInstance(RequestProcessingContextReference.class);
+            return reference.get().request();
+        };
+    }
+
+    private static class QueryParamInjectionResolver extends ParamInjectionResolver<QueryParam> {
+        @Inject
+        public QueryParamInjectionResolver(final Provider<MultivaluedParameterExtractorProvider> mpep, final InjectionManager injectionManager) {
+            super(new CollectionValueParamProvider.CollectionQueryParamProvider(mpep, injectionManager), QueryParam.class, getContainerRequestProvider(injectionManager));
+        }
+    }
+
+    private static class FormParamInjectionResolver extends ParamInjectionResolver<FormParam> {
+        @Inject
+        public FormParamInjectionResolver(final Provider<MultivaluedParameterExtractorProvider> mpep, final InjectionManager injectionManager) {
+            super(new CollectionValueParamProvider.CollectionFormParamProvider(mpep, injectionManager), FormParam.class, getContainerRequestProvider(injectionManager));
+        }
+    }
+
+    private static class HeaderParamInjectionResolver extends ParamInjectionResolver<HeaderParam> {
+        @Inject
+        public HeaderParamInjectionResolver(final Provider<MultivaluedParameterExtractorProvider> mpep, final InjectionManager injectionManager) {
+            super(new CollectionValueParamProvider.CollectionHeaderParamProvider(mpep, injectionManager), HeaderParam.class, getContainerRequestProvider(injectionManager));
+        }
+    }
+}

--- a/src/main/java/io/dropwizard/vavr/jersey/CollectionParamFeature.java
+++ b/src/main/java/io/dropwizard/vavr/jersey/CollectionParamFeature.java
@@ -1,0 +1,12 @@
+package io.dropwizard.vavr.jersey;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+public class CollectionParamFeature implements Feature {
+    @Override
+    public boolean configure(final FeatureContext context) {
+        context.register(new CollectionParamBinder());
+        return true;
+    }
+}

--- a/src/main/java/io/dropwizard/vavr/jersey/CollectionParameterExtractor.java
+++ b/src/main/java/io/dropwizard/vavr/jersey/CollectionParameterExtractor.java
@@ -1,0 +1,45 @@
+package io.dropwizard.vavr.jersey;
+
+import io.vavr.collection.Seq;
+import io.vavr.control.Option;
+import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractor;
+
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+class CollectionParameterExtractor<A, B extends Seq<String>> implements MultivaluedParameterExtractor<Seq<A>> {
+    private final String name;
+    private final Option<String> defaultValue;
+    private final Function<String, A> fromString;
+    private final Function<List<String>, B> collBuilder;
+
+    CollectionParameterExtractor(final String name,
+                                 final Option<String> defaultValue,
+                                 final Function<String, A> fromString,
+                                 final Function<List<String>, B> collBuilder) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.fromString = fromString;
+        this.collBuilder = collBuilder;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getDefaultValueString() {
+        return this.defaultValue.getOrNull();
+    }
+
+    @Override
+    public Seq<A> extract(final MultivaluedMap<String, String> parameters) {
+        return this.collBuilder.apply(
+            Option.of(parameters.get(this.name))
+                .getOrElse(() -> defaultValue.map(Collections::singletonList).getOrElse(Collections.emptyList()))
+        ).map(this.fromString);
+    }
+}

--- a/src/main/java/io/dropwizard/vavr/jersey/CollectionValueParamProvider.java
+++ b/src/main/java/io/dropwizard/vavr/jersey/CollectionValueParamProvider.java
@@ -1,0 +1,141 @@
+package io.dropwizard.vavr.jersey;
+
+import io.vavr.collection.Array;
+import io.vavr.collection.List;
+import io.vavr.collection.Vector;
+import io.vavr.control.Option;
+import io.vavr.control.Try;
+import org.glassfish.jersey.internal.inject.InjectionManager;
+import org.glassfish.jersey.internal.inject.Providers;
+import org.glassfish.jersey.internal.util.ReflectionHelper;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ParamException;
+import org.glassfish.jersey.server.internal.inject.AbstractValueParamProvider;
+import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractor;
+import org.glassfish.jersey.server.internal.inject.MultivaluedParameterExtractorProvider;
+import org.glassfish.jersey.server.model.Parameter;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.function.Function;
+
+abstract class CollectionValueParamProvider extends AbstractValueParamProvider {
+    private final InjectionManager injectionManager;
+
+    protected CollectionValueParamProvider(final Provider<MultivaluedParameterExtractorProvider> mpep,
+                                           final InjectionManager injectionManager,
+                                           final Parameter.Source... compatibleSources) {
+        super(mpep, compatibleSources);
+        this.injectionManager = injectionManager;
+    }
+
+    @Override
+    protected Function<ContainerRequest, ?> createValueProvider(final Parameter parameter) {
+        final Option<String> name = Option.of(parameter.getSourceName());
+        final Option<String> defaultValue = Option.of(parameter.getDefaultValue());
+
+        return name
+            .filter(n -> !n.isEmpty())
+            .flatMap(n ->
+                findParamConverter(parameter.getType(), parameter.getAnnotations())
+                    .map(conv -> (Function<String, Object>) conv::fromString)
+                    .flatMap(conv -> buildExtractor(parameter.getRawType(), n, defaultValue, conv))
+                    .map(extractor -> buildProvider(extractor, !parameter.isEncoded()))
+            )
+            .getOrNull();
+    }
+
+    private Option<MultivaluedParameterExtractor<?>> buildExtractor(final Class<?> rawClass,
+                                                                    final String name,
+                                                                    final Option<String> defaultValue,
+                                                                    final Function<String, Object> conv) {
+        if (rawClass.equals(Vector.class)) {
+            return Option.of(new CollectionParameterExtractor<>(name, defaultValue, conv, Vector::ofAll));
+        } else if (rawClass.equals(List.class)) {
+            return Option.of(new CollectionParameterExtractor<>(name, defaultValue, conv, List::ofAll));
+        } else if (rawClass.equals(Array.class)) {
+            return Option.of(new CollectionParameterExtractor<>(name, defaultValue, conv, Array::ofAll));
+        } else {
+            return Option.none();
+        }
+    }
+
+    protected abstract Function<ContainerRequest, ?> buildProvider(final MultivaluedParameterExtractor<?> extractor, final boolean decode);
+
+    @SuppressWarnings("unchecked")
+    private Option<ParamConverter<Object>> findParamConverter(final Type type, final Annotation[] annotations) {
+        return List.ofAll(ReflectionHelper.getTypeArgumentAndClass(type))
+            .headOption()
+            .flatMap(ctp -> {
+                if (ctp.rawClass().equals(String.class)) {
+                    return Option.<ParamConverter<Object>>some(new ParamConverter<Object>() {
+                        @Override
+                        public Object fromString(final String value) {
+                            return value;
+                        }
+
+                        @Override
+                        public String toString(final Object value) {
+                            return value.toString();
+                        }
+                    });
+                } else {
+                    return List.ofAll(Providers.getProviders(this.injectionManager, ParamConverterProvider.class)).flatMap(provider ->
+                        Option.of((ParamConverter<Object>) provider.getConverter(ctp.rawClass(), ctp.type(), annotations))
+                    ).headOption();
+                }
+            });
+    }
+
+    static class CollectionQueryParamProvider extends CollectionValueParamProvider {
+        @Inject
+        public CollectionQueryParamProvider(final Provider<MultivaluedParameterExtractorProvider> mpep, final InjectionManager injectionManager) {
+            super(mpep, injectionManager, Parameter.Source.QUERY);
+        }
+
+        @Override
+        protected Function<ContainerRequest, ?> buildProvider(final MultivaluedParameterExtractor<?> extractor, boolean decode) {
+            return containerRequest -> Try.of(() -> {
+                final MultivaluedMap<String, String> parameters = containerRequest.getUriInfo().getQueryParameters(decode);
+                return extractor.extract(parameters);
+            }).getOrElseThrow(e -> new ParamException.QueryParamException(e.getCause(), extractor.getName(), extractor.getDefaultValueString()));
+        }
+    }
+
+    static class CollectionFormParamProvider extends CollectionValueParamProvider {
+        @Inject
+        public CollectionFormParamProvider(final Provider<MultivaluedParameterExtractorProvider> mpep, final InjectionManager injectionManager) {
+            super(mpep, injectionManager, Parameter.Source.FORM);
+        }
+
+        @Override
+        protected Function<ContainerRequest, ?> buildProvider(final MultivaluedParameterExtractor<?> extractor, boolean decode) {
+            return containerRequest ->
+                Try.of(() -> {
+                    containerRequest.bufferEntity();
+                    final Form form = containerRequest.readEntity(Form.class);
+                    return extractor.extract(form.asMap());
+                }).getOrElseThrow(e -> new ParamException.FormParamException(e.getCause(), extractor.getName(), extractor.getDefaultValueString()));
+        }
+    }
+
+    static class CollectionHeaderParamProvider extends CollectionValueParamProvider {
+        @Inject
+        public CollectionHeaderParamProvider(final Provider<MultivaluedParameterExtractorProvider> mpep, final InjectionManager injectionManager) {
+            super(mpep, injectionManager, Parameter.Source.HEADER);
+        }
+
+        @Override
+        protected Function<ContainerRequest, ?> buildProvider(final MultivaluedParameterExtractor<?> extractor, boolean decode) {
+            return containerRequest -> Try
+                .of(() -> extractor.extract(containerRequest.getHeaders()))
+                .getOrElseThrow(e -> new ParamException.HeaderParamException(e.getCause(), extractor.getName(), extractor.getDefaultValueString()));
+        }
+    }
+}

--- a/src/test/java/io/dropwizard/vavr/jersey/CollectionValueParamProviderTest.java
+++ b/src/test/java/io/dropwizard/vavr/jersey/CollectionValueParamProviderTest.java
@@ -1,0 +1,170 @@
+package io.dropwizard.vavr.jersey;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
+import io.dropwizard.logging.BootstrapLogging;
+import io.vavr.collection.Array;
+import io.vavr.collection.List;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Vector;
+import io.vavr.jackson.datatype.VavrModule;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Test;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CollectionValueParamProviderTest extends JerseyTest {
+    static {
+        BootstrapLogging.bootstrap();
+    }
+
+    @Override
+    protected Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        return DropwizardResourceConfig.forTesting(new MetricRegistry())
+            .register(new JacksonMessageBodyProvider(new ObjectMapper().registerModule(new VavrModule())))
+            .register(CollectionParamFeature.class)
+            .register(TestResource.class);
+    }
+
+    @Test
+    public void headerElements() {
+        assertThat(
+            target("/header")
+                .request()
+                .header("paramV", "Foobar V")
+                .header("paramV", "Baz V")
+                .header("paramL", "Foobar L")
+                .header("paramL", "Baz L")
+                .header("paramA", "Foobar A")
+                .header("paramA", "Baz A")
+                .get(new GenericType<java.util.List<String>>() {})
+        ).containsExactly(
+            "Foobar V",
+            "Baz V",
+            "Foobar L",
+            "Baz L",
+            "Foobar A",
+            "Baz A"
+        );
+    }
+
+    @Test
+    public void headersEmpty() {
+        assertThat(
+            target("/header")
+                .request()
+                .get(new GenericType<java.util.List<String>>() {})
+        ).isEmpty();
+    }
+
+    @Test
+    public void queryElements() {
+        assertThat(
+            target("/query")
+                .queryParam("paramV", "Foobar V")
+                .queryParam("paramV", "Baz V")
+                .queryParam("paramL", "Foobar L")
+                .queryParam("paramL", "Baz L")
+                .queryParam("paramA", "Foobar A")
+                .queryParam("paramA", "Baz A")
+                .request()
+                .get(new GenericType<java.util.List<String>>() {})
+        ).containsExactly(
+            "Foobar V",
+            "Baz V",
+            "Foobar L",
+            "Baz L",
+            "Foobar A",
+            "Baz A"
+        );
+    }
+
+    @Test
+    public void queryEmpty() {
+        assertThat(
+            target("/query")
+                .request()
+                .get(new GenericType<java.util.List<String>>() {})
+        ).isEmpty();
+    }
+
+    @Test
+    public void formElements() {
+        final Entity<Form> entity = Entity.form(
+            new Form()
+                .param("paramV", "Foobar V")
+                .param("paramV", "Baz V")
+                .param("paramL", "Foobar L")
+                .param("paramL", "Baz L")
+                .param("paramA", "Foobar A")
+                .param("paramA", "Baz A")
+        );
+        assertThat(
+            target("/form")
+                .request()
+                .post(entity, new GenericType<java.util.List<String>>() {})
+        ).containsExactly(
+            "Foobar V",
+            "Baz V",
+            "Foobar L",
+            "Baz L",
+            "Foobar A",
+            "Baz A"
+        );
+    }
+
+    @Test
+    public void formEmpty() {
+        final Entity<Form> entity = Entity.form(new Form());
+        assertThat(
+            target("/form")
+                .request()
+                .post(entity, new GenericType<java.util.List<String>>() {})
+        ).isEmpty();
+    }
+
+    @Path("/")
+    @Produces(MediaType.APPLICATION_JSON)
+    public static class TestResource {
+        @GET
+        @Path("header")
+        public Seq<String> header(@HeaderParam("paramV") final Vector<String> paramV,
+                                  @HeaderParam("paramL") final List<String> paramL,
+                                  @HeaderParam("paramA") final Array<String> paramA) {
+            return Vector.ofAll(paramV).appendAll(paramL).appendAll(paramA);
+        }
+
+        @GET
+        @Path("query")
+        public Seq<String> query(@QueryParam("paramV") final Vector<String> paramV,
+                                 @QueryParam("paramL") final List<String> paramL,
+                                 @QueryParam("paramA") final Array<String> paramA) {
+            return Vector.ofAll(paramV).appendAll(paramL).appendAll(paramA);
+        }
+
+        @POST
+        @Path("form")
+        public Seq<String> form(@FormParam("paramV") final Vector<String> paramV,
+                                @FormParam("paramL") final List<String> paramL,
+                                @FormParam("paramA") final Array<String> paramA) {
+            return Vector.ofAll(paramV).appendAll(paramL).appendAll(paramA);
+        }
+    }
+}


### PR DESCRIPTION
This adds support for injecting Vavr `List`, `Vector`, and `Array` into resource methods using `@HeaderParam`, `@QueryParam`, and `@FormParam`.

This PR is for the Dropwizard 2.0.x branch.